### PR TITLE
Corrected global variable in body thief quest.

### DIFF
--- a/gavin/quest/questbaf/b!quest.baf
+++ b/gavin/quest/questbaf/b!quest.baf
@@ -859,7 +859,7 @@ END
 /* Talk to PC about Body Thief Quest */
 IF %BGT_VAR%
   InParty(Myself)
-  Global("B!GavinBTQuest","GLOBAL",4)
+  Global("B!GavinBodyThiefQuest","GLOBAL",4)
   Global("B!DiscussBT","GLOBAL",0)
   !AreaCheck("%Temple_SongoftheMorning%")
   !Global("X#AjantisCoranChallenge","GLOBAL",1)  


### PR DESCRIPTION
This misspelled global variable can cause Gavin's final quest to fail to start properly.  "B!GavinBTQuest" is not used anywhere else, it's "B!GavinBodyThiefQuest" in all other dialogues and scripts.