### PR TITLE
Fix Gavin's action responses in BGEE.

### DIFF
--- a/gavin/gavin.tp2
+++ b/gavin/gavin.tp2
@@ -693,6 +693,20 @@ COPY ~Gavin/CRE/B!GAVIN.CRE~ ~override~
   SAY SET_A_TRAP @48
   SAY BIO @49
 
+//Change BG2 soundset setup to BGEE
+ACTION_IF GAME_IS ~bgee~ BEGIN
+  COPY_EXISTING ~B!GAVIN.CRE~ ~override~
+    SAY 0x1E0 @35              //  SAY BGEE_ACTION4 @35
+    SAY 0x1E4 @36              //  SAY BGEE_ACTION5 @36
+    SAY 0x1E8 @37              //  SAY BGEE_ACTION6 @37
+    SAY 0x1EC @38              //  SAY BGEE_ACTION7 @38
+    WRITE_LONG SELECT_ACTION4 (BNOT 0x0)
+    WRITE_LONG SELECT_ACTION5 (BNOT 0x0)
+    WRITE_LONG SELECT_ACTION6 (BNOT 0x0)
+    WRITE_LONG SELECT_ACTION7 (BNOT 0x0)
+  BUT_ONLY
+END
+
 
 //2da appending for dialogues
 


### PR DESCRIPTION
In BGEE, SELECT_ACTION4-7 does not play on move as in BG2, but on multiple clicks. Most NPC mods however assume that, because these mods were written based on TuTu/BGT/EET which are all BG1-in-BG2 setups and BGEE's SNDSLOT.IDS does not acknowledge the issue either.

2.6 patch named 4 priorly-unused slots in the cre file as BGEE_ACTION4-7 for these actions. This patch moves Gavin's appropriate
lines to those slots.